### PR TITLE
Fixed datetime naive bug at ovkv6subscriber by changing all

### DIFF
--- a/api/src/apps/objectstore/archive_pgtables.py
+++ b/api/src/apps/objectstore/archive_pgtables.py
@@ -1,10 +1,11 @@
 import argparse
-import datetime
 import glob
 import logging
 import os
 import subprocess
 import sys
+
+from django.utils import timezone
 
 logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 log = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ class Archiver(object):
     avoid version conflict because we dump in copy format.
     """
     def make_stamp(self, dt=None):
-        ts = dt if dt else datetime.datetime.now()
+        ts = dt if dt else timezone.now()
         return ts.strftime("%Y%m%d-%H%M%S")
 
     def __init__(self, tmp_folder=None):

--- a/api/src/apps/ov/kv6xml.py
+++ b/api/src/apps/ov/kv6xml.py
@@ -1,17 +1,18 @@
 import logging
 import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from dateutil.parser import parse
 from django.contrib.gis.geos import Point
 from django.db import models
+from django.utils import timezone
 
 from apps.ov.bulk_inserter import bulk_inserter
 from apps.ov.models import OvKv6, OvRoutes, OvRouteSection, OvStop
 
 logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
 NS = {'tmi8': 'http://bison.connekt.nl/tmi8/kv6/msg'}
 KV6KEY = '{' + NS['tmi8'] + '}' + 'KV6posinfo'
 
@@ -104,8 +105,9 @@ class Kv6XMLProcessor(object):
             for key in keys:
                 subdict = self.journeys[key]
                 m = max(subdict.values())
+
                 # no update on this route for more than a day, remove it
-                if m and m + timedelta(days=1) <= datetime.now():
+                if m and m + timedelta(days=1) <= timezone.now():
                     del self.journeys[key]
 
     def remove_journey(self, dataowner, line, journey):

--- a/api/src/apps/ov/management/commands/kv6sub.py
+++ b/api/src/apps/ov/management/commands/kv6sub.py
@@ -2,10 +2,9 @@
 # pylint: disable=unbalanced-tuple-unpacking
 import gzip
 import logging
-from datetime import datetime
 
-from dateutil.tz import tzlocal
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from apps.ov.bulk_inserter import bulk_inserter
 from apps.ov.kv6xml import Kv6XMLProcessor
@@ -38,7 +37,7 @@ class KV6Subscriber(ZmqSubscriber):
             record = OvRaw(feed=envelop, xml=contents)
             self.inserter.add(record)
             unpacked = gzip.decompress(record.xml).decode('utf-8')
-            now = datetime.now(tzlocal())
+            now = timezone.now()
             self.xmlprocessor.process(now, unpacked)
         else:
             log.info(f'Skipping envelop {envelop}')

--- a/api/src/apps/ov/tests/test_kv6.py
+++ b/api/src/apps/ov/tests/test_kv6.py
@@ -5,10 +5,10 @@ import time
 from datetime import datetime
 
 import zmq
-from dateutil.tz import tzlocal
 from django.contrib.gis.geos import Point
 from django.db import connection
 from django.test import TransactionTestCase
+from django.utils import timezone
 
 from apps.ov.bulk_inserter import bulk_inserter
 from apps.ov.kv6xml import Kv6XMLProcessor
@@ -236,7 +236,7 @@ class MockSubscriber(ZmqSubscriber):
             record = OvRaw(feed=envelop, xml=contents)
             self.inserter.add(record)
             unpacked = gzip.decompress(record.xml).decode('utf-8')
-            now = datetime.now(tzlocal())
+            now = timezone.now()
             self.xmlprocessor.process(now, unpacked)
 
 

--- a/api/src/apps/ov/zmq_base_client.py
+++ b/api/src/apps/ov/zmq_base_client.py
@@ -2,9 +2,10 @@
 # pylint: disable=unbalanced-tuple-unpacking
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.db import connection
+from django.utils import timezone
 
 from apps.ov.zmq_poller import ZmqPoller
 
@@ -41,10 +42,10 @@ class ZmqBaseClient(object):
             return False
 
     def check_refresh(self):
-        if self.next_refresh is None or self.next_refresh <= datetime.now():
+        if self.next_refresh is None or self.next_refresh <= timezone.now():
             for sub in self.subscribers:
                 sub.handle_refreshdata()
-            self.next_refresh = datetime.now() + timedelta(days=1)
+            self.next_refresh = timezone.now() + timedelta(days=1)
 
     def message_loop(self):
         while True:


### PR DESCRIPTION
datetime.now() to django's timezone.now() for consistency

There was a date calculation occuring between naive and non naive date
which caused the ovkv6 sub to get stuck in an endless loop. The solution
was to keep the django project consistent with django's own
timezone.now() to avoid any discrepencies in the future.